### PR TITLE
docs: remove outdated packages from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ The **Status** column represents:
 | ------- | ------------ | ------ | ----- |
 | [d3-geo-polygon](https://www.npmjs.com/package/d3-geo-polygon)       | N/A | ⚠️ | [#22](https://github.com/wandering-app/types-ohq-d3/issues/22) |
 | [d3-geo-projection](https://www.npmjs.com/package/d3-geo-projection) | N/A | ⚠️ | [#23](https://github.com/wandering-app/types-ohq-d3/issues/23) |
-| [d3-cam16](https://www.npmjs.com/package/d3-cam16)                   | N/A | ⚠️ | [#24](https://github.com/wandering-app/types-ohq-d3/issues/24) |
 | [d3-tile](https://www.npmjs.com/package/d3-tile)                     | N/A | 🛠️ | [#26](https://github.com/wandering-app/types-ohq-d3/issues/26) |
-| [d3-hcg](https://www.npmjs.com/package/d3-hcg)                       | N/A | 🛠️ | [#27](https://github.com/wandering-app/types-ohq-d3/issues/27) |
 
 ## License
 This library is licensed under the MIT license ([`LICENSE-MIT`](./LICENSE) or http://opensource.org/licenses/MIT).


### PR DESCRIPTION
d3-cam16 and d3-hcg packages were never published to NPM, so don't add either packages to support roadmap